### PR TITLE
Add french keymap based on Xorg french-latin9 keyboard layout

### DIFF
--- a/keymaps/fr.keymap
+++ b/keymaps/fr.keymap
@@ -1,0 +1,12 @@
+ & "'(- _  )=
+ azertyuiop^$
+ qsdfghjklm *
+<wxcvbn,;:!
+ 1234567890 +
+ AZERTYUIOP
+ QSDFGHJKLM%
+>WXCVBN?./
+  ~#{[|`\^@]}
+           ~
+
+|          


### PR DESCRIPTION
This keymap is based on Xorg's french-latin9 keyboard layout (I used “setxkbmap fr latin9“ to do it).
Please note that it could be a better idea to use Windows default french layout since french keymaps  on Linux (simple or latin9) have a lot of special chars with alt gr.