### PR TITLE
Create Spanish (Spain) keymap

### DIFF
--- a/keymaps/es.keymap.txt
+++ b/keymaps/es.keymap.txt
@@ -1,0 +1,11 @@
+º1234567890'¡
+ qwertyuiop`+
+ asdfghjklñ´ç
+<zxcvbnm,.-
+ª!"·$%&/()=?¿
+ QWERTYUIOP^*
+ ASDFGHJKLÑ¨Ç
+>ZXCVBNM;:_
+
+
+


### PR DESCRIPTION
The key next to the `ñ` is used for accents in `áéíóú`, when pressed on its own, no character is put out. When pressed twice, then the keyboard produces the accent character `´`. However, when pressed once, then the spacebar, it produces the apostrophe `'`. This last behaviour is not commonly known, so this could be ignored or separated into an alternative Spanish keymap.