### PR TITLE
Convert fr.keymap to ISO-8859-15 and add missing characters

### DIFF
--- a/keymaps/fr.keymap
+++ b/keymaps/fr.keymap
@@ -1,12 +1,12 @@
- & "'(- _  )=
+²&é"'(-è_çà)=
  azertyuiop^$
- qsdfghjklm *
+ qsdfghjklmù*
 <wxcvbn,;:!
- 1234567890 +
- AZERTYUIOP
- QSDFGHJKLM%
->WXCVBN?./
-  ~#{[|`\^@]}
-           ~
-
-|          
+~1234567890°+
+ AZERTYUIOP £
+ QSDFGHJKLM%µ
+>WXCVBN?./§
+¬¹~#{[|`\^@]}
+ æ«¤¶        
+ ÂøÊ±æðÛÎÔ¹²³
+|     n    


### PR DESCRIPTION
This PR adds 8-bits characters to the french keymap and converts it to ISO-8859-15.