### PR TITLE
Add Italian keymap(s) / base chars

### DIFF
--- a/basechars/it.base
+++ b/basechars/it.base
@@ -1,0 +1,1 @@
+!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~èéòàùìÉÈÓÒÀÙÌ

--- a/keymaps/it.keymap
+++ b/keymaps/it.keymap
@@ -1,0 +1,12 @@
+1234567890'ì
+qwertyuiopè+
+asdfghjklòàù
+zxcvbnm,.-
+!"£$%&/()=?^
+QWERTYUIOPÉ*
+ASDFGHJKLÒÀÙ
+ZXCVBNM;:_
+@#€§|"'ì
+[{}]
+"""
+<>

--- a/keymaps/it_mac.keymap
+++ b/keymaps/it_mac.keymap
@@ -1,0 +1,12 @@
+1234567890'- 
+qwertyuiopè+ 
+asdfghjklòàù 
+zxcvbnm,.- 
+!"£$%&/()=?^ 
+QWERTYUIOPÉ* 
+ASDFGHJKLÒÀÙ 
+ZXCVBNM;:_ 
+@#€§|\"'ì 
+[{}] 
+""' 
+<>


### PR DESCRIPTION
Two minor addition to the code base: keymap for both Italian & Italian_mac keyboard layouts plus a dedicated base-chars.