### PR TITLE
fix UB in keymap parser

### DIFF
--- a/src/kwp.c
+++ b/src/kwp.c
@@ -376,6 +376,18 @@ static int check_keymap_line_width(size_t line_len, int total_line_num, const ch
   return RC_OK;
 }
 
+static wchar_t* read_keymap_line(FILE *fp, wchar_t *tmp_buf, const char *section_name, int section_row)
+{
+  wchar_t *line_buf = fgetl(fp, tmp_buf, BUFSIZ);
+
+  if (line_buf == NULL)
+  {
+    fprintf(stderr, "ERROR: Keymap file is incomplete. Expected line for %s map, row %d.\n", section_name, section_row);
+  }
+
+  return line_buf;
+}
+
 int parse_keymap_file (FILE *fp, wchar_t keymap_basic[KEYMAP_WIDTH][KEYMAP_HEIGHT], wchar_t keymap_shift[KEYMAP_WIDTH][KEYMAP_HEIGHT], wchar_t keymap_altgr[KEYMAP_WIDTH][KEYMAP_HEIGHT])
 {
   wchar_t *tmp = (wchar_t *) calloc (BUFSIZ, sizeof (wchar_t));
@@ -384,9 +396,8 @@ int parse_keymap_file (FILE *fp, wchar_t keymap_basic[KEYMAP_WIDTH][KEYMAP_HEIGH
 
   for (int y = 0; y < 4; y++)
   {
-    wchar_t *line_buf = fgetl (fp, tmp, BUFSIZ);
-
-    if (line_buf == NULL) continue;
+    wchar_t *line_buf = read_keymap_line(fp, tmp, "basic", y + 1);
+    if (line_buf == NULL) { free(tmp); return RC_INVALID; }
 
     const size_t line_len = wcslen (line_buf);
 
@@ -410,9 +421,8 @@ int parse_keymap_file (FILE *fp, wchar_t keymap_basic[KEYMAP_WIDTH][KEYMAP_HEIGH
 
   for (int y = 0; y < 4; y++)
   {
-    wchar_t *line_buf = fgetl (fp, tmp, BUFSIZ);
-
-    if (line_buf == NULL) continue;
+    wchar_t *line_buf = read_keymap_line(fp, tmp, "shift", y + 1);
+    if (line_buf == NULL) { free(tmp); return RC_INVALID; }
 
     const size_t line_len = wcslen (line_buf);
 
@@ -436,9 +446,8 @@ int parse_keymap_file (FILE *fp, wchar_t keymap_basic[KEYMAP_WIDTH][KEYMAP_HEIGH
 
   for (int y = 0; y < 4; y++)
   {
-    wchar_t *line_buf = fgetl (fp, tmp, BUFSIZ);
-
-    if (line_buf == NULL) continue;
+    wchar_t *line_buf = read_keymap_line(fp, tmp, "altgr", y + 1);
+    if (line_buf == NULL) { free(tmp); return RC_INVALID; }
 
     const size_t line_len = wcslen (line_buf);
 

--- a/src/kwp.c
+++ b/src/kwp.c
@@ -24,7 +24,7 @@
 #define MOD_CNT               3
 #define DIR_CNT               9
 
-#define KEYMAP_WIDTH          13
+#define KEYMAP_WIDTH          14
 #define KEYMAP_HEIGHT         4
 #define KEYMAP_ENTRIES        (KEYMAP_WIDTH * KEYMAP_HEIGHT)
 
@@ -364,6 +364,18 @@ wchar_t *fgetl (FILE *fp, wchar_t *buf, int len)
   return line_buf;
 }
 
+static int check_keymap_line_width(size_t line_len, int total_line_num, const char *section_name, int section_row)
+{
+  if (line_len > KEYMAP_WIDTH)
+  {
+    fprintf(stderr, "ERROR: Keymap file format error.\n");
+    fprintf(stderr, "       Line %d (%s map, row %d) is too long.\n", total_line_num, section_name, section_row);
+    fprintf(stderr, "       Maximum allowed width is %d characters, but this line has %zu.\n", KEYMAP_WIDTH, line_len);
+    return RC_INVALID;
+  }
+  return RC_OK;
+}
+
 int parse_keymap_file (FILE *fp, wchar_t keymap_basic[KEYMAP_WIDTH][KEYMAP_HEIGHT], wchar_t keymap_shift[KEYMAP_WIDTH][KEYMAP_HEIGHT], wchar_t keymap_altgr[KEYMAP_WIDTH][KEYMAP_HEIGHT])
 {
   wchar_t *tmp = (wchar_t *) calloc (BUFSIZ, sizeof (wchar_t));
@@ -377,6 +389,12 @@ int parse_keymap_file (FILE *fp, wchar_t keymap_basic[KEYMAP_WIDTH][KEYMAP_HEIGH
     if (line_buf == NULL) continue;
 
     const size_t line_len = wcslen (line_buf);
+
+    if (check_keymap_line_width(line_len, y + 1, "basic", y + 1) != RC_OK)
+    {
+        free(tmp);
+        return RC_INVALID;
+    }
 
     for (size_t x = 0; x < line_len; x++)
     {
@@ -398,6 +416,12 @@ int parse_keymap_file (FILE *fp, wchar_t keymap_basic[KEYMAP_WIDTH][KEYMAP_HEIGH
 
     const size_t line_len = wcslen (line_buf);
 
+    if (check_keymap_line_width(line_len, y + 5, "shift", y + 1) != RC_OK)
+    {
+        free(tmp);
+        return RC_INVALID;
+    }
+
     for (size_t x = 0; x < line_len; x++)
     {
       wchar_t c = line_buf[x];
@@ -417,6 +441,12 @@ int parse_keymap_file (FILE *fp, wchar_t keymap_basic[KEYMAP_WIDTH][KEYMAP_HEIGH
     if (line_buf == NULL) continue;
 
     const size_t line_len = wcslen (line_buf);
+
+    if (check_keymap_line_width(line_len, y + 9, "altgr", y + 1) != RC_OK)
+    {
+        free(tmp);
+        return RC_INVALID;
+    }
 
     for (size_t x = 0; x < line_len; x++)
     {

--- a/src/kwp.c
+++ b/src/kwp.c
@@ -1016,6 +1016,7 @@ int main (int argc, char *argv[])
   out_flush (out);
 
   free (routes_buf);
+  free(basechars_buf);
   free (css);
   free (out);
 


### PR DESCRIPTION
Hi.

This was found when for some reason i decided to build kwp with default -O2 from makefile and without it, and found that output was not equal. You can repro this with building master and running `./kwp basechars/tiny.base keymaps/en-us.keymap routes/4-to-4-exhaustive.route > test.default.txt` and then remove -O2 from makefile, rebuild and run again  `./kwp basechars/tiny.base keymaps/en-us.keymap routes/4-to-4-exhaustive.route > test.noopt.txt` and diff files - noopt version will be bigger.
first few entries, default/noopt:
```
1qaz 1qaz
1234 1234
qwer qwer
12ws 12ws
qwsx qwsx
q1qa q1qa
121` 121`
1qwe qwq|
qasd 1qwe
1`12 qasd    
```
`qwq|` looks wrong, `|` shouldn't be reachable.

So I've rebuild with sanitizers and tried to fix few found issues.

First commit fixes OOB read and adds error message for it; second checks that all 12 lines present in file; 3rd one fixes leak - it shouldn't be really matter, but fix is 1 line of code, so, why not?